### PR TITLE
Update postcss [SECURITY]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4042,8 +4042,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.41:
-    resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prefers-yarn@1.0.1:
@@ -4215,6 +4215,11 @@ packages:
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -4430,6 +4435,10 @@ packages:
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -5928,201 +5937,201 @@ snapshots:
 
   '@csstools/normalize.css@12.1.1': {}
 
-  '@csstools/postcss-cascade-layers@4.0.6(postcss@8.4.41)':
+  '@csstools/postcss-cascade-layers@4.0.6(postcss@8.5.10)':
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  '@csstools/postcss-color-function@3.0.19(postcss@8.4.41)':
+  '@csstools/postcss-color-function@3.0.19(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-color-mix-function@2.0.19(postcss@8.4.41)':
+  '@csstools/postcss-color-mix-function@2.0.19(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-content-alt-text@1.0.0(postcss@8.4.41)':
+  '@csstools/postcss-content-alt-text@1.0.0(postcss@8.5.10)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-exponential-functions@1.0.9(postcss@8.4.41)':
+  '@csstools/postcss-exponential-functions@1.0.9(postcss@8.5.10)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-font-format-keywords@3.0.2(postcss@8.4.41)':
+  '@csstools/postcss-font-format-keywords@3.0.2(postcss@8.5.10)':
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-gamut-mapping@1.0.11(postcss@8.4.41)':
+  '@csstools/postcss-gamut-mapping@1.0.11(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-gradients-interpolation-method@4.0.20(postcss@8.4.41)':
+  '@csstools/postcss-gradients-interpolation-method@4.0.20(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-hwb-function@3.0.18(postcss@8.4.41)':
+  '@csstools/postcss-hwb-function@3.0.18(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-ic-unit@3.0.7(postcss@8.4.41)':
+  '@csstools/postcss-ic-unit@3.0.7(postcss@8.5.10)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-initial@1.0.1(postcss@8.4.41)':
+  '@csstools/postcss-initial@1.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-is-pseudo-class@4.0.8(postcss@8.4.41)':
+  '@csstools/postcss-is-pseudo-class@4.0.8(postcss@8.5.10)':
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  '@csstools/postcss-light-dark-function@1.0.8(postcss@8.4.41)':
+  '@csstools/postcss-light-dark-function@1.0.8(postcss@8.5.10)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-logical-float-and-clear@2.0.1(postcss@8.4.41)':
+  '@csstools/postcss-logical-float-and-clear@2.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-logical-overflow@1.0.1(postcss@8.4.41)':
+  '@csstools/postcss-logical-overflow@1.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-logical-overscroll-behavior@1.0.1(postcss@8.4.41)':
+  '@csstools/postcss-logical-overscroll-behavior@1.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-logical-resize@2.0.1(postcss@8.4.41)':
+  '@csstools/postcss-logical-resize@2.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-logical-viewport-units@2.0.11(postcss@8.4.41)':
+  '@csstools/postcss-logical-viewport-units@2.0.11(postcss@8.5.10)':
     dependencies:
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-media-minmax@1.1.8(postcss@8.4.41)':
+  '@csstools/postcss-media-minmax@1.1.8(postcss@8.5.10)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-media-queries-aspect-ratio-number-values@2.0.11(postcss@8.4.41)':
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@2.0.11(postcss@8.5.10)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-nested-calc@3.0.2(postcss@8.4.41)':
+  '@csstools/postcss-nested-calc@3.0.2(postcss@8.5.10)':
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@3.0.2(postcss@8.4.41)':
+  '@csstools/postcss-normalize-display-values@3.0.2(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-oklab-function@3.0.19(postcss@8.4.41)':
+  '@csstools/postcss-oklab-function@3.0.19(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-progressive-custom-properties@3.3.0(postcss@8.4.41)':
+  '@csstools/postcss-progressive-custom-properties@3.3.0(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-relative-color-syntax@2.0.19(postcss@8.4.41)':
+  '@csstools/postcss-relative-color-syntax@2.0.19(postcss@8.5.10)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  '@csstools/postcss-scope-pseudo-class@3.0.1(postcss@8.4.41)':
+  '@csstools/postcss-scope-pseudo-class@3.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  '@csstools/postcss-stepped-value-functions@3.0.10(postcss@8.4.41)':
+  '@csstools/postcss-stepped-value-functions@3.0.10(postcss@8.5.10)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-text-decoration-shorthand@3.0.7(postcss@8.4.41)':
+  '@csstools/postcss-text-decoration-shorthand@3.0.7(postcss@8.5.10)':
     dependencies:
       '@csstools/color-helpers': 4.2.1
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-trigonometric-functions@3.0.10(postcss@8.4.41)':
+  '@csstools/postcss-trigonometric-functions@3.0.10(postcss@8.5.10)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  '@csstools/postcss-unset-value@3.0.1(postcss@8.4.41)':
+  '@csstools/postcss-unset-value@3.0.1(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   '@csstools/selector-resolve-nested@1.1.0(postcss-selector-parser@6.1.2)':
     dependencies:
@@ -6136,9 +6145,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@csstools/utilities@1.0.0(postcss@8.4.41)':
+  '@csstools/utilities@1.0.0(postcss@8.5.10)':
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
@@ -6283,19 +6292,19 @@ snapshots:
       less: 4.2.0
       less-loader: 12.2.0(less@4.2.0)(webpack@5.92.1)
       mini-css-extract-plugin: 2.9.0(webpack@5.92.1)
-      postcss: 8.4.41
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.41)
-      postcss-loader: 8.1.1(postcss@8.4.41)(typescript@6.0.3)(webpack@5.92.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.1)(postcss@8.4.41)
-      postcss-preset-env: 9.6.0(postcss@8.4.41)
-      postcss-scss: 4.0.9(postcss@8.4.41)
+      postcss: 8.5.10
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.10)
+      postcss-loader: 8.1.1(postcss@8.5.10)(typescript@6.0.3)(webpack@5.92.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.1)(postcss@8.5.10)
+      postcss-preset-env: 9.6.0(postcss@8.5.10)
+      postcss-scss: 4.0.9(postcss@8.5.10)
       react-refresh: 0.14.2
       sass: 1.77.8
       sass-loader: 14.2.1(sass@1.77.8)(webpack@5.92.1)
       slugify: 1.6.6
       style-loader: 3.3.4(webpack@5.92.1)
       stylelint: 16.8.2(typescript@6.0.3)
-      stylelint-config-standard-scss: 13.1.0(postcss@8.4.41)(stylelint@16.8.2(typescript@6.0.3))
+      stylelint-config-standard-scss: 13.1.0(postcss@8.5.10)(stylelint@16.8.2(typescript@6.0.3))
       stylelint-webpack-plugin: 5.0.1(stylelint@16.8.2(typescript@6.0.3))(webpack@5.92.1)
       ts-loader: 9.5.1(typescript@6.0.3)(webpack@5.92.1)
       vue-loader: 17.4.2(@vue/compiler-sfc@3.4.38)(webpack@5.92.1)
@@ -7104,7 +7113,7 @@ snapshots:
       '@vue/shared': 3.4.38
       estree-walker: 2.0.2
       magic-string: 0.30.11
-      postcss: 8.4.41
+      postcss: 8.5.10
       source-map-js: 1.2.0
 
   '@vue/compiler-ssr@3.4.38':
@@ -7336,14 +7345,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.20(postcss@8.4.41):
+  autoprefixer@10.4.20(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001765
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -7677,36 +7686,36 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-blank-pseudo@6.0.2(postcss@8.4.41):
+  css-blank-pseudo@6.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
   css-functions-list@3.2.2: {}
 
-  css-has-pseudo@6.0.5(postcss@8.4.41):
+  css-has-pseudo@6.0.5(postcss@8.5.10):
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
   css-loader@6.11.0(webpack@5.92.1):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.41)
-      postcss: 8.4.41
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.41)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.41)
-      postcss-modules-scope: 3.2.0(postcss@8.4.41)
-      postcss-modules-values: 4.0.0(postcss@8.4.41)
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.10)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.5.10)
+      postcss-modules-scope: 3.2.0(postcss@8.5.10)
+      postcss-modules-values: 4.0.0(postcss@8.5.10)
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
       webpack: 5.92.1
 
-  css-prefers-color-scheme@9.0.1(postcss@8.4.41):
+  css-prefers-color-scheme@9.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   css-tree@2.3.1:
     dependencies:
@@ -8013,7 +8022,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.16.1
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -8741,9 +8750,9 @@ snapshots:
       safer-buffer: 2.1.2
     optional: true
 
-  icss-utils@5.1.0(postcss@8.4.41):
+  icss-utils@5.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   ignore@5.3.2: {}
 
@@ -9418,299 +9427,299 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-attribute-case-insensitive@6.0.3(postcss@8.4.41):
+  postcss-attribute-case-insensitive@6.0.3(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-browser-comments@4.0.0(browserslist@4.28.1)(postcss@8.4.41):
+  postcss-browser-comments@4.0.0(browserslist@4.28.1)(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-clamp@4.1.0(postcss@8.4.41):
+  postcss-clamp@4.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@6.0.14(postcss@8.4.41):
+  postcss-color-functional-notation@6.0.14(postcss@8.5.10):
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  postcss-color-hex-alpha@9.0.4(postcss@8.4.41):
+  postcss-color-hex-alpha@9.0.4(postcss@8.5.10):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@9.0.3(postcss@8.4.41):
+  postcss-color-rebeccapurple@9.0.3(postcss@8.5.10):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@10.0.8(postcss@8.4.41):
+  postcss-custom-media@10.0.8(postcss@8.5.10):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-custom-properties@13.3.12(postcss@8.4.41):
+  postcss-custom-properties@13.3.12(postcss@8.5.10):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@7.1.12(postcss@8.4.41):
+  postcss-custom-selectors@7.1.12(postcss@8.5.10):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-dir-pseudo-class@8.0.1(postcss@8.4.41):
+  postcss-dir-pseudo-class@8.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-double-position-gradients@5.0.7(postcss@8.4.41):
+  postcss-double-position-gradients@5.0.7(postcss@8.5.10):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-flexbugs-fixes@5.0.2(postcss@8.4.41):
+  postcss-flexbugs-fixes@5.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-focus-visible@9.0.1(postcss@8.4.41):
+  postcss-focus-visible@9.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-focus-within@8.0.1(postcss@8.4.41):
+  postcss-focus-within@8.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-font-variant@5.0.0(postcss@8.4.41):
+  postcss-font-variant@5.0.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-gap-properties@5.0.1(postcss@8.4.41):
+  postcss-gap-properties@5.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-image-set-function@6.0.3(postcss@8.4.41):
+  postcss-image-set-function@6.0.3(postcss@8.5.10):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-import@15.1.0(postcss@8.4.41):
+  postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.0.1(postcss@8.4.41):
+  postcss-js@4.0.1(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-lab-function@6.0.19(postcss@8.4.41):
+  postcss-lab-function@6.0.19(postcss@8.5.10):
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/utilities': 1.0.0(postcss@8.4.41)
-      postcss: 8.4.41
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/utilities': 1.0.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  postcss-load-config@4.0.2(postcss@8.4.41):
+  postcss-load-config@4.0.2(postcss@8.5.10):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.8.1
     optionalDependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-loader@8.1.1(postcss@8.4.41)(typescript@6.0.3)(webpack@5.92.1):
+  postcss-loader@8.1.1(postcss@8.5.10)(typescript@6.0.3)(webpack@5.92.1):
     dependencies:
       cosmiconfig: 9.0.0(typescript@6.0.3)
       jiti: 1.21.6
-      postcss: 8.4.41
+      postcss: 8.5.10
       semver: 7.7.3
     optionalDependencies:
       webpack: 5.92.1
     transitivePeerDependencies:
       - typescript
 
-  postcss-logical@7.0.1(postcss@8.4.41):
+  postcss-logical@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   postcss-media-query-parser@0.2.3: {}
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.41):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-modules-local-by-default@4.0.5(postcss@8.4.41):
+  postcss-modules-local-by-default@4.0.5(postcss@8.5.10):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.41)
-      postcss: 8.4.41
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.0(postcss@8.4.41):
+  postcss-modules-scope@3.2.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-values@4.0.0(postcss@8.4.41):
+  postcss-modules-values@4.0.0(postcss@8.5.10):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.41)
-      postcss: 8.4.41
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  postcss-nested@6.2.0(postcss@8.4.41):
+  postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-nesting@12.1.5(postcss@8.4.41):
+  postcss-nesting@12.1.5(postcss@8.5.10):
     dependencies:
       '@csstools/selector-resolve-nested': 1.1.0(postcss-selector-parser@6.1.2)
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-normalize@10.0.1(browserslist@4.28.1)(postcss@8.4.41):
+  postcss-normalize@10.0.1(browserslist@4.28.1)(postcss@8.5.10):
     dependencies:
       '@csstools/normalize.css': 12.1.1
       browserslist: 4.28.1
-      postcss: 8.4.41
-      postcss-browser-comments: 4.0.0(browserslist@4.28.1)(postcss@8.4.41)
+      postcss: 8.5.10
+      postcss-browser-comments: 4.0.0(browserslist@4.28.1)(postcss@8.5.10)
       sanitize.css: 13.0.0
 
-  postcss-opacity-percentage@2.0.0(postcss@8.4.41):
+  postcss-opacity-percentage@2.0.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-overflow-shorthand@5.0.1(postcss@8.4.41):
+  postcss-overflow-shorthand@5.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.4.41):
+  postcss-page-break@3.0.4(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-place@9.0.1(postcss@8.4.41):
+  postcss-place@9.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@9.6.0(postcss@8.4.41):
+  postcss-preset-env@9.6.0(postcss@8.5.10):
     dependencies:
-      '@csstools/postcss-cascade-layers': 4.0.6(postcss@8.4.41)
-      '@csstools/postcss-color-function': 3.0.19(postcss@8.4.41)
-      '@csstools/postcss-color-mix-function': 2.0.19(postcss@8.4.41)
-      '@csstools/postcss-content-alt-text': 1.0.0(postcss@8.4.41)
-      '@csstools/postcss-exponential-functions': 1.0.9(postcss@8.4.41)
-      '@csstools/postcss-font-format-keywords': 3.0.2(postcss@8.4.41)
-      '@csstools/postcss-gamut-mapping': 1.0.11(postcss@8.4.41)
-      '@csstools/postcss-gradients-interpolation-method': 4.0.20(postcss@8.4.41)
-      '@csstools/postcss-hwb-function': 3.0.18(postcss@8.4.41)
-      '@csstools/postcss-ic-unit': 3.0.7(postcss@8.4.41)
-      '@csstools/postcss-initial': 1.0.1(postcss@8.4.41)
-      '@csstools/postcss-is-pseudo-class': 4.0.8(postcss@8.4.41)
-      '@csstools/postcss-light-dark-function': 1.0.8(postcss@8.4.41)
-      '@csstools/postcss-logical-float-and-clear': 2.0.1(postcss@8.4.41)
-      '@csstools/postcss-logical-overflow': 1.0.1(postcss@8.4.41)
-      '@csstools/postcss-logical-overscroll-behavior': 1.0.1(postcss@8.4.41)
-      '@csstools/postcss-logical-resize': 2.0.1(postcss@8.4.41)
-      '@csstools/postcss-logical-viewport-units': 2.0.11(postcss@8.4.41)
-      '@csstools/postcss-media-minmax': 1.1.8(postcss@8.4.41)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 2.0.11(postcss@8.4.41)
-      '@csstools/postcss-nested-calc': 3.0.2(postcss@8.4.41)
-      '@csstools/postcss-normalize-display-values': 3.0.2(postcss@8.4.41)
-      '@csstools/postcss-oklab-function': 3.0.19(postcss@8.4.41)
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.4.41)
-      '@csstools/postcss-relative-color-syntax': 2.0.19(postcss@8.4.41)
-      '@csstools/postcss-scope-pseudo-class': 3.0.1(postcss@8.4.41)
-      '@csstools/postcss-stepped-value-functions': 3.0.10(postcss@8.4.41)
-      '@csstools/postcss-text-decoration-shorthand': 3.0.7(postcss@8.4.41)
-      '@csstools/postcss-trigonometric-functions': 3.0.10(postcss@8.4.41)
-      '@csstools/postcss-unset-value': 3.0.1(postcss@8.4.41)
-      autoprefixer: 10.4.20(postcss@8.4.41)
+      '@csstools/postcss-cascade-layers': 4.0.6(postcss@8.5.10)
+      '@csstools/postcss-color-function': 3.0.19(postcss@8.5.10)
+      '@csstools/postcss-color-mix-function': 2.0.19(postcss@8.5.10)
+      '@csstools/postcss-content-alt-text': 1.0.0(postcss@8.5.10)
+      '@csstools/postcss-exponential-functions': 1.0.9(postcss@8.5.10)
+      '@csstools/postcss-font-format-keywords': 3.0.2(postcss@8.5.10)
+      '@csstools/postcss-gamut-mapping': 1.0.11(postcss@8.5.10)
+      '@csstools/postcss-gradients-interpolation-method': 4.0.20(postcss@8.5.10)
+      '@csstools/postcss-hwb-function': 3.0.18(postcss@8.5.10)
+      '@csstools/postcss-ic-unit': 3.0.7(postcss@8.5.10)
+      '@csstools/postcss-initial': 1.0.1(postcss@8.5.10)
+      '@csstools/postcss-is-pseudo-class': 4.0.8(postcss@8.5.10)
+      '@csstools/postcss-light-dark-function': 1.0.8(postcss@8.5.10)
+      '@csstools/postcss-logical-float-and-clear': 2.0.1(postcss@8.5.10)
+      '@csstools/postcss-logical-overflow': 1.0.1(postcss@8.5.10)
+      '@csstools/postcss-logical-overscroll-behavior': 1.0.1(postcss@8.5.10)
+      '@csstools/postcss-logical-resize': 2.0.1(postcss@8.5.10)
+      '@csstools/postcss-logical-viewport-units': 2.0.11(postcss@8.5.10)
+      '@csstools/postcss-media-minmax': 1.1.8(postcss@8.5.10)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 2.0.11(postcss@8.5.10)
+      '@csstools/postcss-nested-calc': 3.0.2(postcss@8.5.10)
+      '@csstools/postcss-normalize-display-values': 3.0.2(postcss@8.5.10)
+      '@csstools/postcss-oklab-function': 3.0.19(postcss@8.5.10)
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.10)
+      '@csstools/postcss-relative-color-syntax': 2.0.19(postcss@8.5.10)
+      '@csstools/postcss-scope-pseudo-class': 3.0.1(postcss@8.5.10)
+      '@csstools/postcss-stepped-value-functions': 3.0.10(postcss@8.5.10)
+      '@csstools/postcss-text-decoration-shorthand': 3.0.7(postcss@8.5.10)
+      '@csstools/postcss-trigonometric-functions': 3.0.10(postcss@8.5.10)
+      '@csstools/postcss-unset-value': 3.0.1(postcss@8.5.10)
+      autoprefixer: 10.4.20(postcss@8.5.10)
       browserslist: 4.28.1
-      css-blank-pseudo: 6.0.2(postcss@8.4.41)
-      css-has-pseudo: 6.0.5(postcss@8.4.41)
-      css-prefers-color-scheme: 9.0.1(postcss@8.4.41)
+      css-blank-pseudo: 6.0.2(postcss@8.5.10)
+      css-has-pseudo: 6.0.5(postcss@8.5.10)
+      css-prefers-color-scheme: 9.0.1(postcss@8.5.10)
       cssdb: 8.1.0
-      postcss: 8.4.41
-      postcss-attribute-case-insensitive: 6.0.3(postcss@8.4.41)
-      postcss-clamp: 4.1.0(postcss@8.4.41)
-      postcss-color-functional-notation: 6.0.14(postcss@8.4.41)
-      postcss-color-hex-alpha: 9.0.4(postcss@8.4.41)
-      postcss-color-rebeccapurple: 9.0.3(postcss@8.4.41)
-      postcss-custom-media: 10.0.8(postcss@8.4.41)
-      postcss-custom-properties: 13.3.12(postcss@8.4.41)
-      postcss-custom-selectors: 7.1.12(postcss@8.4.41)
-      postcss-dir-pseudo-class: 8.0.1(postcss@8.4.41)
-      postcss-double-position-gradients: 5.0.7(postcss@8.4.41)
-      postcss-focus-visible: 9.0.1(postcss@8.4.41)
-      postcss-focus-within: 8.0.1(postcss@8.4.41)
-      postcss-font-variant: 5.0.0(postcss@8.4.41)
-      postcss-gap-properties: 5.0.1(postcss@8.4.41)
-      postcss-image-set-function: 6.0.3(postcss@8.4.41)
-      postcss-lab-function: 6.0.19(postcss@8.4.41)
-      postcss-logical: 7.0.1(postcss@8.4.41)
-      postcss-nesting: 12.1.5(postcss@8.4.41)
-      postcss-opacity-percentage: 2.0.0(postcss@8.4.41)
-      postcss-overflow-shorthand: 5.0.1(postcss@8.4.41)
-      postcss-page-break: 3.0.4(postcss@8.4.41)
-      postcss-place: 9.0.1(postcss@8.4.41)
-      postcss-pseudo-class-any-link: 9.0.2(postcss@8.4.41)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.41)
-      postcss-selector-not: 7.0.2(postcss@8.4.41)
+      postcss: 8.5.10
+      postcss-attribute-case-insensitive: 6.0.3(postcss@8.5.10)
+      postcss-clamp: 4.1.0(postcss@8.5.10)
+      postcss-color-functional-notation: 6.0.14(postcss@8.5.10)
+      postcss-color-hex-alpha: 9.0.4(postcss@8.5.10)
+      postcss-color-rebeccapurple: 9.0.3(postcss@8.5.10)
+      postcss-custom-media: 10.0.8(postcss@8.5.10)
+      postcss-custom-properties: 13.3.12(postcss@8.5.10)
+      postcss-custom-selectors: 7.1.12(postcss@8.5.10)
+      postcss-dir-pseudo-class: 8.0.1(postcss@8.5.10)
+      postcss-double-position-gradients: 5.0.7(postcss@8.5.10)
+      postcss-focus-visible: 9.0.1(postcss@8.5.10)
+      postcss-focus-within: 8.0.1(postcss@8.5.10)
+      postcss-font-variant: 5.0.0(postcss@8.5.10)
+      postcss-gap-properties: 5.0.1(postcss@8.5.10)
+      postcss-image-set-function: 6.0.3(postcss@8.5.10)
+      postcss-lab-function: 6.0.19(postcss@8.5.10)
+      postcss-logical: 7.0.1(postcss@8.5.10)
+      postcss-nesting: 12.1.5(postcss@8.5.10)
+      postcss-opacity-percentage: 2.0.0(postcss@8.5.10)
+      postcss-overflow-shorthand: 5.0.1(postcss@8.5.10)
+      postcss-page-break: 3.0.4(postcss@8.5.10)
+      postcss-place: 9.0.1(postcss@8.5.10)
+      postcss-pseudo-class-any-link: 9.0.2(postcss@8.5.10)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.10)
+      postcss-selector-not: 7.0.2(postcss@8.5.10)
 
-  postcss-pseudo-class-any-link@9.0.2(postcss@8.4.41):
+  postcss-pseudo-class-any-link@9.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.4.41):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   postcss-resolve-nested-selector@0.1.6: {}
 
-  postcss-safe-parser@7.0.0(postcss@8.4.41):
+  postcss-safe-parser@7.0.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-scss@4.0.9(postcss@8.4.41):
+  postcss-scss@4.0.9(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
-  postcss-selector-not@7.0.2(postcss@8.4.41):
+  postcss-selector-not@7.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -9720,11 +9729,11 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.41:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   prefers-yarn@1.0.1: {}
 
@@ -9903,6 +9912,14 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    optional: true
 
   retry@0.13.1: {}
 
@@ -10146,6 +10163,8 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
+  source-map-js@1.2.1: {}
+
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
@@ -10258,26 +10277,26 @@ snapshots:
     dependencies:
       webpack: 5.92.1
 
-  stylelint-config-recommended-scss@14.1.0(postcss@8.4.41)(stylelint@16.8.2(typescript@6.0.3)):
+  stylelint-config-recommended-scss@14.1.0(postcss@8.5.10)(stylelint@16.8.2(typescript@6.0.3)):
     dependencies:
-      postcss-scss: 4.0.9(postcss@8.4.41)
+      postcss-scss: 4.0.9(postcss@8.5.10)
       stylelint: 16.8.2(typescript@6.0.3)
       stylelint-config-recommended: 14.0.1(stylelint@16.8.2(typescript@6.0.3))
       stylelint-scss: 6.5.0(stylelint@16.8.2(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   stylelint-config-recommended@14.0.1(stylelint@16.8.2(typescript@6.0.3)):
     dependencies:
       stylelint: 16.8.2(typescript@6.0.3)
 
-  stylelint-config-standard-scss@13.1.0(postcss@8.4.41)(stylelint@16.8.2(typescript@6.0.3)):
+  stylelint-config-standard-scss@13.1.0(postcss@8.5.10)(stylelint@16.8.2(typescript@6.0.3)):
     dependencies:
       stylelint: 16.8.2(typescript@6.0.3)
-      stylelint-config-recommended-scss: 14.1.0(postcss@8.4.41)(stylelint@16.8.2(typescript@6.0.3))
+      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.10)(stylelint@16.8.2(typescript@6.0.3))
       stylelint-config-standard: 36.0.1(stylelint@16.8.2(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.4.41
+      postcss: 8.5.10
 
   stylelint-config-standard@36.0.1(stylelint@16.8.2(typescript@6.0.3)):
     dependencies:
@@ -10334,9 +10353,9 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.41
+      postcss: 8.5.10
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 7.0.0(postcss@8.4.41)
+      postcss-safe-parser: 7.0.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -10401,11 +10420,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.41
-      postcss-import: 15.1.0(postcss@8.4.41)
-      postcss-js: 4.0.1(postcss@8.4.41)
-      postcss-load-config: 4.0.2(postcss@8.4.41)
-      postcss-nested: 6.2.0(postcss@8.4.41)
+      postcss: 8.5.10
+      postcss-import: 15.1.0(postcss@8.5.10)
+      postcss-js: 4.0.1(postcss@8.5.10)
+      postcss-load-config: 4.0.2(postcss@8.5.10)
+      postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.0


### PR DESCRIPTION
This PR updates dependencies from a `dependabot_alert` webhook.

- Updated packages: `postcss`
- GHSA: GHSA-qx2v-qp2m-jg93
- Advisory: https://github.com/advisories/GHSA-qx2v-qp2m-jg93
- Severity: medium
- Ecosystem: npm

Created through [dependabot-alert-bridge](https://github.com/karlhorky/dependabot-alert-bridge)