### PR TITLE
Update ws [SECURITY]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4983,8 +4983,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10604,7 +10604,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.92.1)
-      ws: 8.18.0
+      ws: 8.20.0
     optionalDependencies:
       webpack: 5.92.1
     transitivePeerDependencies:
@@ -10632,7 +10632,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.92.1
       webpack-target-webextension: 1.1.2(webpack@5.92.1)
-      ws: 8.18.0
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10649,7 +10649,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.92.1
       webpack-target-webextension: 1.1.2(webpack@5.92.1)
-      ws: 8.18.0
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10800,7 +10800,7 @@ snapshots:
 
   ws@8.17.1: {}
 
-  ws@8.18.0: {}
+  ws@8.20.0: {}
 
   xml2js@0.6.2:
     dependencies:


### PR DESCRIPTION
This PR updates dependencies from a `dependabot_alert` webhook.

- Updated packages: `ws`
- GHSA: GHSA-58qx-3vcg-4xpx
- Advisory: https://github.com/advisories/GHSA-58qx-3vcg-4xpx
- Severity: medium
- Ecosystem: npm

Created through [dependabot-alert-bridge](https://github.com/karlhorky/dependabot-alert-bridge)