### PR TITLE
Update webpack-dev-server [SECURITY]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4851,8 +4851,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.3:
-    resolution: {integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==}
+  webpack-dev-server@5.2.4:
+    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -6193,7 +6193,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@colors/colors': 1.6.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.35.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.92.1))(webpack@5.92.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.35.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.92.1))(webpack@5.92.1)
       '@types/adm-zip': 0.5.5
       '@types/chrome': 0.0.268
       '@types/webextension-polyfill': 0.10.7
@@ -6243,7 +6243,7 @@ snapshots:
       webpack-browser-extension-resolve: 1.2.0(webpack@5.92.1)
       webpack-browser-extension-resources: 1.2.0(webpack@5.92.1)
       webpack-browser-extension-scripts: 1.2.0(webpack@5.92.1)
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.92.1)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.92.1)
       webpack-merge: 5.10.0
       webpack-run-chrome-extension: 1.3.2(webpack@5.92.1)
       webpack-run-edge-extension: 1.3.1(webpack@5.92.1)
@@ -6578,7 +6578,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.35.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.92.1))(webpack@5.92.1)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.35.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.92.1))(webpack@5.92.1)':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.38.0
@@ -6591,7 +6591,7 @@ snapshots:
       webpack: 5.92.1
     optionalDependencies:
       type-fest: 4.35.0
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.92.1)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.92.1)
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -10575,7 +10575,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.92.1):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.92.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
This PR updates dependencies from a `dependabot_alert` webhook.

- Updated packages: `webpack-dev-server`
- GHSA: GHSA-79cf-xcqc-c78w
- Advisory: https://github.com/advisories/GHSA-79cf-xcqc-c78w
- Severity: medium
- Ecosystem: npm

Created through [dependabot-alert-bridge](https://github.com/karlhorky/dependabot-alert-bridge)